### PR TITLE
Fix imports for helper utilities

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,4 +1,4 @@
-import { H3Event } from 'h3';
+import { H3Event, readRawBody } from 'h3';
 
 export function hasBody(event: H3Event) {
   const method = event.method.toUpperCase();

--- a/src/utils/ip.ts
+++ b/src/utils/ip.ts
@@ -1,4 +1,4 @@
-import { EventHandlerRequest, H3Event } from 'h3';
+import { EventHandlerRequest, H3Event, getHeader } from 'h3';
 
 export function getIp(event: H3Event<EventHandlerRequest>) {
   const value = getHeader(event, 'CF-Connecting-IP');

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -3,7 +3,10 @@ import {
   Duplex,
   ProxyOptions,
   getProxyRequestHeaders,
+  getRequestWebStream,
+  readRawBody,
   RequestHeaders,
+  sendProxy,
 } from 'h3';
 
 const PayloadMethods = new Set(['PATCH', 'POST', 'PUT', 'DELETE']);

--- a/src/utils/sending.ts
+++ b/src/utils/sending.ts
@@ -1,4 +1,4 @@
-import { H3Event, EventHandlerRequest } from 'h3';
+import { H3Event, EventHandlerRequest, send, setResponseStatus } from 'h3';
 
 export async function sendJson(ops: {
   event: H3Event<EventHandlerRequest>;


### PR DESCRIPTION
## Summary
- add missing imports from `h3`

## Testing
- `pnpm lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b4a2b6188323802c305dac30780f